### PR TITLE
Added comparing request url to canonical to disable printing

### DIFF
--- a/src/Calotype/SEO/Generators/MetaGenerator.php
+++ b/src/Calotype/SEO/Generators/MetaGenerator.php
@@ -1,5 +1,6 @@
 <?php namespace Calotype\SEO\Generators;
 
+use Illuminate\Support\Facades\Request;
 use Calotype\SEO\Contracts\MetaAware;
 
 class MetaGenerator
@@ -86,7 +87,11 @@ class MetaGenerator
         }
 
         if (! empty($canonical)) {
-            $html[] = "<link rel='canonical' href='$canonical' />";
+            $url = Request::fullUrl();
+            
+            if ($canonical != $url) {
+                $html[] = "<link rel='canonical' href='$canonical' />";
+            }
         }
 
         return implode(PHP_EOL, $html);

--- a/tests/Calotype/SEO/Generators/MetaGeneratorTest.php
+++ b/tests/Calotype/SEO/Generators/MetaGeneratorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Request;
 use Calotype\SEO\Generators\MetaGenerator;
 
 class MetaGeneratorTest extends PHPUnit_Framework_TestCase
@@ -66,6 +67,8 @@ class MetaGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testCanSetCanonical()
     {
+        Request::shouldReceive('fullUrl')->once()->andReturn('http://example.org?utm_source=google');
+        
         $generator = $this->getGenerator();
 
         $generator->setCanonical('http://example.org');
@@ -76,6 +79,8 @@ class MetaGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testCanSetFromObject()
     {
+        Request::shouldReceive('fullUrl')->once()->andReturn('http://example.org?utm_source=google');
+        
         $generator = $this->getGenerator();
         $object = $this->getObjectMock($this->getValidProperties());
         $generator->fromObject($object);
@@ -95,6 +100,8 @@ class MetaGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testCanResetMetas()
     {
+        Request::shouldReceive('fullUrl')->once()->andReturn('http://foobar.baz?utm_source=google');
+        
         $generator = $this->getGenerator();
 
         $generator->setTitle('Bar');


### PR DESCRIPTION
Disabled rendering canonical if request url matches canonical url to prevent recursive canonical redirect.

You are supposed to hide the canonical URL if it matches the same URL that is requested. I saw [this package](https://github.com/Crisu83/yii-seo/blob/master/widgets/SeoHead.php#L111) a while back and it has a if to prevent printing it if it is the same URL including scheme and query string.

So here's a unit test example:

Visited page: http://google.com

Canonical: http://google.com
Print: No

Canonical: **https**://google.com
Print: No

Canonical: http://google.com **?login=true**
Print: Yes

What do you think @bryantebeek?
